### PR TITLE
Change autoload_disable example to package name

### DIFF
--- a/project-template/{{ project_repo_name }}/README.md
+++ b/project-template/{{ project_repo_name }}/README.md
@@ -23,7 +23,7 @@ This xontrib will get loaded automatically for interactive sessions.
 To stop this, set
 
 ```xonsh
-$XONTRIBS_AUTOLOAD_DISABLED = {"ptk_shell", }
+$XONTRIBS_AUTOLOAD_DISABLED = {"{{project_package_name}}", }
 ```
 {% else %}
 ```bash


### PR DESCRIPTION
Uses template variable instead of hard-coding `"ptk_shell"`
partially addresses https://github.com/xonsh/xontrib-template/issues/18