### PR TITLE
Update poetry-core version

### DIFF
--- a/project-template/{{ project_repo_name }}/pyproject.toml
+++ b/project-template/{{ project_repo_name }}/pyproject.toml
@@ -78,7 +78,7 @@ dev = ["pytest>=7.0"]
 
 {% if package_manager == 'poetry' %}
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.3.0"]
 build-backend = "poetry.core.masonry.api"
 {% else %}
 [build-system]


### PR DESCRIPTION
Fixes CVE-2022-26184 warning with poetry below v1.1.9

Got a warning for one of my xontribs using this template, would this simple poetry version bump work?